### PR TITLE
correcting jest rules names #36

### DIFF
--- a/rules/jest/off.js
+++ b/rules/jest/off.js
@@ -4,58 +4,58 @@ module.exports = {
   plugins: ["jest"],
   rules: {
     // Enforce consistent test or it keyword
-    "consistent-test-it": 0,
+    "jest/consistent-test-it": 0,
     // Enforce assertion to be made in a test body
-    "expect-expect": 0,
+    "jest/expect-expect": 0,
     // Disallow capitalized test names
-    "lowercase-name": 0,
+    "jest/lowercase-name": 0,
     // Disallow alias methods
-    "no-alias-methods": 0,
+    "jest/no-alias-methods": 0,
     // Disallow disabled tests
-    "no-disabled-tests": 0,
+    "jest/no-disabled-tests": 0,
     // Disallow focused tests
-    "no-focused-tests": 0,
+    "jest/no-focused-tests": 0,
     // Disallow setup and teardown hooks
-    "no-hooks": 0,
+    "jest/no-hooks": 0,
     // Disallow identical titles
-    "no-identical-title": 0,
+    "jest/no-identical-title": 0,
     // Disallow Jasmine globals
-    "no-jasmine-globals": 0,
+    "jest/no-jasmine-globals": 0,
     // Disallow importing jest
-    "no-jest-import": 0,
+    "jest/no-jest-import": 0,
     // Disallow large snapshots
-    "no-large-snapshots": 0,
+    "jest/no-large-snapshots": 0,
     // Using a callback in asynchronous tests
-    "no-test-callback": 0,
+    "jest/no-test-callback": 0,
     // Disallow using f & x prefixes to define focused/skipped tests
-    "no-test-prefixes": 0,
+    "jest/no-test-prefixes": 0,
     // Disallow explicitly returning from tests
-    "no-test-return-statement": 0,
+    "jest/no-test-return-statement": 0,
     // Disallow using toBeTruthy() & toBeFalsy()
-    "no-truthy-falsy": 0,
+    "jest/no-truthy-falsy": 0,
     // Suggest using expect.assertions() OR expect.hasAssertions()
-    "prefer-expect-assertions": 0,
+    "jest/prefer-expect-assertions": 0,
     // Suggest using jest.spyOn()
-    "prefer-spy-on": 0,
+    "jest/prefer-spy-on": 0,
     // Suggest using toStrictEqual()
-    "prefer-strict-equal": 0,
+    "jest/prefer-strict-equal": 0,
     // Suggest using toBeNull()
-    "prefer-to-be-null": 0,
+    "jest/prefer-to-be-null": 0,
     // Suggest using toBeUndefined()
-    "prefer-to-be-undefined": 0,
+    "jest/prefer-to-be-undefined": 0,
     // Suggest using toContain()
-    "prefer-to-contain": 0,
+    "jest/prefer-to-contain": 0,
     // Suggest using toHaveLength()
-    "prefer-to-have-length": 0,
+    "jest/prefer-to-have-length": 0,
     // Suggest using toMatchInlineSnapshot()
-    "prefer-inline-snapshots": 0,
+    "jest/prefer-inline-snapshots": 0,
     // Require that toThrow() and toThrowError includes a message
-    "require-tothrow-message": 0,
+    "jest/require-tothrow-message": 0,
     // Enforce valid describe() callback
-    "valid-describe": 0,
+    "jest/valid-describe": 0,
     // Enforce having return statement when testing with promises
-    "valid-expect-in-promise": 0,
+    "jest/valid-expect-in-promise": 0,
     // Enforce valid expect() usage
-    "valid-expect": 0
+    "jest/valid-expect": 0
   }
 };

--- a/rules/jest/on.js
+++ b/rules/jest/on.js
@@ -4,58 +4,58 @@ module.exports = {
   plugins: ["jest"],
   rules: {
     // Enforce consistent test or it keyword
-    "consistent-test-it": [2, { fn: "it", withinDescribe: "it" }],
+    "jest/consistent-test-it": [2, { fn: "it", withinDescribe: "it" }],
     // Enforce assertion to be made in a test body
-    "expect-expect": 2,
+    "jest/expect-expect": 2,
     // Disallow capitalized test names
-    "lowercase-name": 2,
+    "jest/lowercase-name": 2,
     // Disallow alias methods
-    "no-alias-methods": 2,
+    "jest/no-alias-methods": 2,
     // Disallow disabled tests
-    "no-disabled-tests": 2,
+    "jest/no-disabled-tests": 2,
     // Disallow focused tests
-    "no-focused-tests": 2,
+    "jest/no-focused-tests": 2,
     // Disallow setup and teardown hooks
-    "no-hooks": 0,
+    "jest/no-hooks": 0,
     // Disallow identical titles
-    "no-identical-title": 2,
+    "jest/no-identical-title": 2,
     // Disallow Jasmine globals
-    "no-jasmine-globals": 2,
+    "jest/no-jasmine-globals": 2,
     // Disallow importing jest
-    "no-jest-import": 2,
+    "jest/no-jest-import": 2,
     // Disallow large snapshots
-    "no-large-snapshots": 0,
+    "jest/no-large-snapshots": 0,
     // Using a callback in asynchronous tests
-    "no-test-callback": 0,
+    "jest/no-test-callback": 0,
     // Disallow using f & x prefixes to define focused/skipped tests
-    "no-test-prefixes": 2,
+    "jest/no-test-prefixes": 2,
     // Disallow explicitly returning from tests
-    "no-test-return-statement": 2,
+    "jest/no-test-return-statement": 2,
     // Disallow using toBeTruthy() & toBeFalsy()
-    "no-truthy-falsy": 0,
+    "jest/no-truthy-falsy": 0,
     // Suggest using expect.assertions() OR expect.hasAssertions()
-    "prefer-expect-assertions": 0,
+    "jest/prefer-expect-assertions": 0,
     // Suggest using jest.spyOn()
-    "prefer-spy-on": 2,
+    "jest/prefer-spy-on": 2,
     // Suggest using toStrictEqual()
-    "prefer-strict-equal": 2,
+    "jest/prefer-strict-equal": 2,
     // Suggest using toBeNull()
-    "prefer-to-be-null": 2,
+    "jest/prefer-to-be-null": 2,
     // Suggest using toBeUndefined()
-    "prefer-to-be-undefined": 2,
+    "jest/prefer-to-be-undefined": 2,
     // Suggest using toContain()
-    "prefer-to-contain": 2,
+    "jest/prefer-to-contain": 2,
     // Suggest using toHaveLength()
-    "prefer-to-have-length": 2,
+    "jest/prefer-to-have-length": 2,
     // Suggest using toMatchInlineSnapshot()
-    "prefer-inline-snapshots": 0,
+    "jest/prefer-inline-snapshots": 0,
     // Require that toThrow() and toThrowError includes a message
-    "require-tothrow-message": 0,
+    "jest/require-tothrow-message": 0,
     // Enforce valid describe() callback
-    "valid-describe": 2,
+    "jest/valid-describe": 2,
     // Enforce having return statement when testing with promises
-    "valid-expect-in-promise": 2,
+    "jest/valid-expect-in-promise": 2,
     // Enforce valid expect() usage
-    "valid-expect": 2
+    "jest/valid-expect": 2
   }
 };


### PR DESCRIPTION
Closes  #36 
**Pull Request summary**
This pr adds `jest/` to every jest related rule. the functionality is tested and it works fine.

**Checklist**

- [x] I have added a meaningful title to my PR
- [x] I have branched out of the latest `master` branch
- [x] The client issue number is included in my PR title
- [x] I have made at least one semantic commit to my PR
- [x] I have connected this pull request with an existing issue on Zenhub
