### PR TITLE
Fixing TSLint Error on "undefinded:undefinded" when having an import lint

### DIFF
--- a/configurations/js-node.js
+++ b/configurations/js-node.js
@@ -44,6 +44,5 @@ module.exports = {
         extensions: [".js"]
       }
     }
-  },
-  rules: {}
+  }
 };

--- a/configurations/js-react.js
+++ b/configurations/js-react.js
@@ -51,6 +51,5 @@ module.exports = {
     react: {
       version: "detect"
     }
-  },
-  rules: {}
+  }
 };

--- a/configurations/ts-node.js
+++ b/configurations/ts-node.js
@@ -10,14 +10,14 @@ module.exports = {
   extends: [
     "plugin:import/errors",
     "plugin:import/warnings",
-    "plugin:import/typescript",
     require.resolve("../configurations/eslint-all"),
     require.resolve("../rules/jest/on"),
     require.resolve("../rules/ts/on")
   ],
   env: {
     jest: true,
-    node: true
+    node: true,
+    es6: true
   },
   globals: {
     global: true,
@@ -44,6 +44,5 @@ module.exports = {
         extensions: [".ts"]
       }
     }
-  },
-  rules: {}
+  }
 };

--- a/configurations/ts-react.js
+++ b/configurations/ts-react.js
@@ -11,14 +11,14 @@ module.exports = {
     "plugin:jsx-a11y/recommended",
     "plugin:import/errors",
     "plugin:import/warnings",
-    "plugin:import/typescript",
     require.resolve("../configurations/eslint-all"),
     require.resolve("../rules/react/on"),
     require.resolve("../rules/jest/on"),
     require.resolve("../rules/ts/on")
   ],
   env: {
-    jest: true
+    jest: true,
+    es6: true
   },
   globals: {
     global: true,
@@ -51,6 +51,5 @@ module.exports = {
     react: {
       version: "detect"
     }
-  },
-  rules: {}
+  }
 };


### PR DESCRIPTION
Closes #79 
**Quick Summary**
The scope was the bug was that `eslint-plugin-import` does not handle the new `@typescript-eslint/parser` and it keep giving the undefined error, both @ardalann and myself; have had a look and for the time being we are ignoring the `import` linting for Typescript

**Additional changes**
- remove all the `rules: {}` from configs

**Checklist**

- [ ] I have added a meaningful title to my PR
- [ ] I have branched out of the latest `master` branch
- [ ] The client issue number is included in my PR title
- [ ] I have made at least one semantic commit to my PR
- [ ] I have connected this pull request with an existing issue on Zenhub
