### PR TITLE
Fixing eslint error in using showroom

### DIFF
--- a/configurations/js-react.js
+++ b/configurations/js-react.js
@@ -39,12 +39,17 @@ module.exports = {
   },
   overrides: [
     {
-      files: ["*.showroom.js", "*.showroom.ts", "*.showroom.tsx", "*.spec.js"],
+      files: ["*.spec.js"],
       rules: {
         "no-magic-numbers": 0
       },
       env: {
-        jest: true,
+        jest: true
+      }
+    },
+    {
+      files: ["*.showroom.js", "*.showroom.ts", "*.showroom.tsx"],
+      env: {
         node: true
       }
     }

--- a/configurations/ts-react.js
+++ b/configurations/ts-react.js
@@ -44,12 +44,17 @@ module.exports = {
   },
   overrides: [
     {
-      files: ["*.showroom.js", "*.showroom.ts", "*.showroom.tsx", "*.spec.js", "*.spec.ts", "*.spec.tsx"],
+      files: ["*.spec.js", "*.spec.ts", "*.spec.tsx"],
       rules: {
         "no-magic-numbers": 0
       },
       env: {
-        jest: true,
+        jest: true
+      }
+    },
+    {
+      files: ["*.showroom.js", "*.showroom.ts", "*.showroom.tsx"],
+      env: {
         node: true
       }
     }


### PR DESCRIPTION
Closes https://github.com/versett/eslint-plugin-versett/issues/105

**Pull Request summary**

When using React + Typescript + Showroom, the module argument in a story (see example below) causes an `no-undef` error with eslint.

**Checklist**

- [x] I have added a meaningful title to my PR
- [x] I have branched out of the latest `master` branch
- [ ] I have run `yarn test` in my local development environment
- [ ] I have tested this PR
- [x] I have made at least one semantic commit to my PR
- [x] I have connected this pull request with an existing issue on Zenhub
- [x] The issue number is included in my PR title
