### PR TITLE
Update options for array-type

### DIFF
--- a/rules/ts/on.js
+++ b/rules/ts/on.js
@@ -6,7 +6,7 @@ module.exports = {
     // Require that member overloads be consecutive
     "@typescript-eslint/adjacent-overload-signatures": 2,
     // Requires using either T[] or Array<T> for arrays
-    "@typescript-eslint/array-type": [2, "generic"],
+    "@typescript-eslint/array-type": [2, { default: "generic" }],
     // Enforces that types will not to be used
     "@typescript-eslint/ban-types": [
       2,


### PR DESCRIPTION
See the rule here: https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/array-type.md

The change to typescript-eslint was made in July this PR is to match that change.

