### PR TITLE
feat(rules): Add rules for react hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,13 +27,13 @@ You must be logged in to you Versett npm account first using `npm login`.
 You have to install the following peer dependencies directly in your project for now by this command:
 
 ```
-yarn add --dev eslint babel-eslint eslint-plugin-jest eslint-plugin-import eslint-config-prettier eslint-plugin-prettier
+yarn add --dev eslint babel-eslint eslint-plugin-jest eslint-plugin-import eslint-config-prettier eslint-plugin-prettier eslint-plugin-react-hooks
 ```
 
 or
 
 ```
-npm install --save-dev eslint babel-eslint eslint-plugin-jest eslint-plugin-import eslint-config-prettier eslint-plugin-prettier
+npm install --save-dev eslint babel-eslint eslint-plugin-jest eslint-plugin-import eslint-config-prettier eslint-plugin-prettier eslint-plugin-react-hooks
 ```
 
 This command will no longer be needed after the issue with `eslint shareable config plugins` is resolved. You can refer to this [RFC](https://github.com/eslint/rfcs/pull/7) for more information.

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "eslint-config-prettier": ">= 4.0.0",
     "eslint-plugin-import": ">= 2.14.0",
     "eslint-plugin-jest": ">= 22.1.3",
-    "eslint-plugin-prettier": ">= 3.0.1"
+    "eslint-plugin-prettier": ">= 3.0.1",
+    "eslint-plugin-react-hooks": ">=2.0.1"
   },
   "husky": {
     "hooks": {

--- a/rules/react/on.js
+++ b/rules/react/on.js
@@ -1,7 +1,7 @@
 "use strict";
 
 module.exports = {
-  plugins: ["react", "jsx-a11y"],
+  plugins: ["react", "jsx-a11y", "react-hooks"],
   rules: {
     // enforces consistent naming for boolean props
     // it must start with "is" or "has" like "isEnabled" or "hasCondition"
@@ -166,6 +166,10 @@ module.exports = {
     "react/jsx-uses-vars": 2,
     // prevent missing parentheses around multilines JSX (fixable)
     "react/jsx-wrap-multilines": 0,
+    // Checks rules of Hooks
+    "react-hooks/rules-of-hooks": 2,
+    // Checks effect dependencies
+    "react-hooks/exhaustive-deps": 2,
     // enforce that a label tag has a text label and an associated control.
     "jsx-a11y/label-has-associated-control": 2,
     // enforce label tags have associated control


### PR DESCRIPTION
Closes #118 

Adds the rules for react hooks, based on the rules here: https://reactjs.org/docs/hooks-rules.html
